### PR TITLE
When parsing, allow comments that appear anywhere on the line

### DIFF
--- a/wikibase/queryService/ui/queryHelper/SparqlQuery.js
+++ b/wikibase/queryService/ui/queryHelper/SparqlQuery.js
@@ -43,7 +43,7 @@ wikibase.queryService.ui.queryHelper.SparqlQuery = ( function( $, wikibase, spar
 			queryComments = [];
 		this._query = parser.parse( query );
 		$.each( query.split( '\n' ), function( index, line ) {
-			if ( line.indexOf( '#' ) === 0 ) {
+			if ( line.trim().indexOf( '#' ) === 0 ) {
 				queryComments.push( line );
 			}
 		} );


### PR DESCRIPTION
Currently, when one presses 'Format query' toolbar button, a parsable query is reformatted, but the comments are lost. Presumably, the comment lines will remain if they can be recognized as such, namely by starting with '#', but only after any leading whitespace is stripped.