### PR TITLE
change sparql endpoint to dbtune

### DIFF
--- a/default-config.json
+++ b/default-config.json
@@ -1,7 +1,7 @@
 {
   "api": {
     "sparql": {
-      "uri": "https://query.wikidata.org/sparql"
+      "uri": "http://dbtune.org/bbc/peel/sparql"
     },
     "wikibase": {
       "uri": "https://www.wikidata.org/w/api.php"

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
 
 			<div id="query-box">
 				<!-- The action URL is also set dynamically inside wikibase/init.js -->
-				<form id="query-form" action="https://query.wikidata.org/bigdata/namespace/wdq/sparql">
+				<form id="query-form" action="http://dbtune.org/bbc/peel/sparql">
 					<div class="query-main">
 						<div class="toolbar">
 							<div class="toolbar-top">

--- a/wikibase/queryService/api/Sparql.js
+++ b/wikibase/queryService/api/Sparql.js
@@ -5,7 +5,7 @@ wikibase.queryService.api = wikibase.queryService.api || {};
 wikibase.queryService.api.Sparql = ( function( $ ) {
 	'use strict';
 
-	var SPARQL_SERVICE_URI = 'https://query.wikidata.org/bigdata/namespace/wdq/sparql',
+  var SPARQL_SERVICE_URI = 'http://dbtune.org/bbc/peel/sparql',
 		ERROR_CODES = {
 			TIMEOUT: 10,
 			MALFORMED: 20,


### PR DESCRIPTION
Il est possible d'envoyer des requêtes a d'autres bases rdf en changeant le Endpoint dans les fichiers default-config.json, wikidata-query-gui/wikibase/queryService/api/Sparql.js et index.html.
J'ai fait le test en remplaçant le Endpoint par http://dbtune.org/bbc/peel/sparql.

J'ai ensuite exécuté la requête suivante, qui a correctement retourné des résultats.

SELECT * WHERE {
  <http://dbtune.org/bbc/peel/artist/05db6fb408fab9c0e50aac3151a590b4> ?pred ?obj .
}
