### PR TITLE
render SMILES strings on the fly in TableResult view

### DIFF
--- a/wikibase/queryService/ui/resultBrowser/TableResultBrowser.js
+++ b/wikibase/queryService/ui/resultBrowser/TableResultBrowser.js
@@ -139,10 +139,16 @@ wikibase.queryService.ui.resultBrowser.TableResultBrowser = ( function( $, windo
 			showPagination = ( this.rows.length > TABLE_PAGE_SIZE );
 
 		jQuery.fn.bootstrapTable.columnDefaults.formatter = function( data, row, index ) {
+
 			if ( !data ) {
 				return '';
 			}
 			self.processVisitors( data, this.field );
+
+            if(this.field == "smilesDepict"){
+                data.type = "smiles";
+            }
+
 			return self._getFormatter().formatValue( data ).html();
 		};
 

--- a/wikibase/queryService/ui/resultBrowser/helper/FormatterHelper.js
+++ b/wikibase/queryService/ui/resultBrowser/helper/FormatterHelper.js
@@ -11,6 +11,7 @@ wikibase.queryService.ui.resultBrowser.helper.FormatterHelper = ( function( $, m
 		COMMONS_FILE_PATH_MEDIAVIEWER = 'https://commons.wikimedia.org/wiki/File:{FILENAME}',
 		DATATYPE_DATETIME = 'http://www.w3.org/2001/XMLSchema#dateTime',
 		TYPE_URI = 'uri',
+        TYPE_SMILES = 'smiles',
 		DATATYPE_STRING = 'http://www.w3.org/2001/XMLSchema#string',
 		DATATYPE_MATHML = 'http://www.w3.org/1998/Math/MathML';
 
@@ -202,6 +203,25 @@ wikibase.queryService.ui.resultBrowser.helper.FormatterHelper = ( function( $, m
 				window.console.error( 'Invalid MathML', e );
 				// fall through to default case, escaping and displaying the raw value
 			} // jshint ignore:line
+
+        case TYPE_SMILES:
+
+            var depictUrl = "https://www.simolecule.com/cdkdepict/depict/bow/svg?smi="+value+"&zoom=2.0&annotate=none&bgcolor=transparent";
+
+            var img = $('<img>');
+            img.attr('src', depictUrl);
+            img.attr('width', "200");
+            img.attr('height', "150");
+
+            var link = $('<a>');
+            link.attr('target','_blank');
+            link.attr('href', depictUrl);
+
+            img.appendTo(link);
+
+            $html.append(link);
+
+            break;
 
 		default:
 			var $label = $( '<span>' ).text( value );

--- a/wikibase/queryService/ui/resultBrowser/helper/FormatterHelper.js
+++ b/wikibase/queryService/ui/resultBrowser/helper/FormatterHelper.js
@@ -212,6 +212,7 @@ wikibase.queryService.ui.resultBrowser.helper.FormatterHelper = ( function( $, m
             img.attr('src', depictUrl);
             img.attr('width', "200");
             img.attr('height', "150");
+            img.attr('onerror', "this.onerror=null;this.src='https://upload.wikimedia.org/wikipedia/commons/b/b1/Missing-image-232x150.png?width=232';");
 
             var link = $('<a>');
             link.attr('target','_blank');


### PR DESCRIPTION
This pull request gives the TableResult view in WDQS the ability to render the SMILES strings of chemical compounds on the fly into an SVG image that is shown directly in the results table. The SMILES depiction uses the [CDK Depict API](https://www.simolecule.com/cdkdepict/depict.html). Also, a placeholder image will be used in case of error in rendering the smiles or handling the request. 
This feature will increase the usability of SPARQL queries that involves SMILES strings and I have heard several researchers in academia favoring having such a feature.
**I appreciate any feedback on the implementation.**
Currently, since the SMILES are just literals, I look for a specific variable named "smilesDepict" and apply the SMILES depiction on its content. So, if the user wants to depict the SMILES into an image, all what is needed is to use the variable ?smilesDepict with the property wdt:P233 (see attached screenshot for a demo). Using any other variable name will show the SMILES as literals.

This is the example query that I used in the demo screenshot:
```sparql
#Chemical compounds SMILES
#defaultView:TableResult
SELECT ?item ?itemLabel ?smilesDepict ?smiles
WHERE
{
  ?item wdt:P31 wd:Q11173.
  ?item wdt:P233 ?smilesDepict .
  BIND(?smilesDepict as ?smiles)
  
  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en" }
}LIMIT 10
``` 

![smiles-depict-demo](https://user-images.githubusercontent.com/43293485/155007610-9aafcbd0-de20-4c90-bfdd-46e00822482f.png)

